### PR TITLE
Use custom User-Agent when sending HTTP requests to CloudWatch Logs API

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -14,4 +14,5 @@
 
 # Please keep the list sorted.
 
+Alvin Wonys <alvin.rw@proton.me>
 Victor Schappert <victor.schappert@protonmail.com> <schapper@amazon.com>

--- a/poller.go
+++ b/poller.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 )
 
@@ -52,7 +53,7 @@ func (p *poller) manipulate(c *chunk) outcome {
 	input := cloudwatchlogs.GetQueryResultsInput{
 		QueryId: &c.queryID,
 	}
-	output, err := p.m.Actions.GetQueryResultsWithContext(c.ctx, &input)
+	output, err := p.m.Actions.GetQueryResultsWithContext(c.ctx, &input, request.WithAppendUserAgent(version()))
 	p.lastReq = time.Now()
 
 	if err != nil {

--- a/starter.go
+++ b/starter.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 )
 
@@ -55,7 +56,7 @@ func (s *starter) manipulate(c *chunk) outcome {
 		LogGroupNames: c.stream.groups,
 		Limit:         &c.stream.Limit,
 	}
-	output, err := s.m.Actions.StartQueryWithContext(c.ctx, &input)
+	output, err := s.m.Actions.StartQueryWithContext(c.ctx, &input, request.WithAppendUserAgent(version()))
 	s.lastReq = time.Now()
 	if err != nil {
 		c.err = &StartQueryError{c.stream.Text, c.start, c.end, err}

--- a/stopper.go
+++ b/stopper.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 )
 
@@ -37,7 +38,7 @@ func (s *stopper) context(_ *chunk) context.Context {
 func (s *stopper) manipulate(c *chunk) outcome {
 	output, err := s.m.Actions.StopQueryWithContext(context.Background(), &cloudwatchlogs.StopQueryInput{
 		QueryId: &c.queryID,
-	})
+	}, request.WithAppendUserAgent(version()))
 	s.lastReq = time.Now()
 	if err != nil && isTemporary(err) {
 		return temporaryError


### PR DESCRIPTION
This PR is to tackle  #18 

Modified the `CloudWatchLogsActions` functions to use the [`request.WithAppendUserAgent(...)`](https://docs.aws.amazon.com/sdk-for-go/api/aws/request/#WithAppendUserAgent) option to append `version()` return value.